### PR TITLE
Call 'next()' on ENOENT errors

### DIFF
--- a/lib/wheat.js
+++ b/lib/wheat.js
@@ -36,8 +36,9 @@ function addRoute(regex, renderer) {
 function handleRoute(req, res, next, renderer, match) {
   function callback(err, data) {
     if (err) {
-      next(err);
-      return;
+      return err.errno === process.ENOENT
+        ? next()
+        : next(err);
     }
     res.writeHead(200, data.headers);
     res.end(data.buffer);


### PR DESCRIPTION
Hey Tim, I'm just trying to clean up the extraneous error message that get printed to my server's `stderr`.

When a Googlebot tries for a "robot.txt", Wheat will call `next(err)` instead of just `next()`, resulting in this:
    Error: git --git-dir=/home/nrajlich/node-http-server/tootallnate.net/blog.git show dbc2ec41609583ce92243936415a772966570ed1:articles/robots.txt
    fatal: ambiguous argument 'dbc2ec41609583ce92243936415a772966570ed1:articles/robots.txt': unknown revision or path not in the working tree.
    Use '--' to separate paths from revisions

```
    at ChildProcess.<anonymous> (/usr/local/lib/node/.npm/git-fs/0.0.4/package/lib/git-fs.js:176:16)
    at ChildProcess.emit (events:33:26)
    at Stream.<anonymous> (child_process:131:12)
    at Stream.emit (events:26:26)
    at Array.0 (net:987:12)
    at EventEmitter._tickCallback (node.js:53:20)
    at node.js:764:9
```

This fixes that, and also goes hand-in-hand with the pull request for `git-fs` I'm about to send to you.
