### PR TITLE
Adding categories/tags support to wheat

### DIFF
--- a/lib/wheat.js
+++ b/lib/wheat.js
@@ -59,7 +59,7 @@ module.exports = function setup(repo) {
   addRoute(/^\/()([a-z0-9_-]+)$/, Renderers.article);
   addRoute(/^\/()(.+\.dot)$/, Renderers.dotFile);
   addRoute(/^\/()(.+\.[a-z]{2,4})$/, Renderers.staticFile);
-	addRoute(/^\/()category\/([a-z0-9_-]+)$/,  Renderers.categoryIndex);
+  addRoute(/^\/()category\/([\%\.a-z0-9_-]+)$/,  Renderers.categoryIndex);
 
 
   return function handle(req, res, next) {

--- a/lib/wheat.js
+++ b/lib/wheat.js
@@ -59,6 +59,7 @@ module.exports = function setup(repo) {
   addRoute(/^\/()([a-z0-9_-]+)$/, Renderers.article);
   addRoute(/^\/()(.+\.dot)$/, Renderers.dotFile);
   addRoute(/^\/()(.+\.[a-z]{2,4})$/, Renderers.staticFile);
+	addRoute(/^\/()category\/([a-z0-9_-]+)$/,  Renderers.categoryIndex);
 
 
   return function handle(req, res, next) {

--- a/lib/wheat/data.js
+++ b/lib/wheat/data.js
@@ -205,6 +205,12 @@ var Data = module.exports = {
           props.version = version;
         }
         props.author = author;
+
+        if(props.categories != undefined){
+          props.categories = props.categories.split(',').map(function(element){ 
+            return element.trim();
+          });
+        }
         return props;
       },
       callback
@@ -293,10 +299,7 @@ var Data = module.exports = {
       function processCategories(err, articles) {
         if (err) { callback(err); return; }
         var categories = articles.reduce(function (start, element) {
-					var articleCategories = element.categories.split(',').map(function(element){ 
-						return element.trim();
-					});
-					articleCategories.forEach(function(category){
+					element.categories.forEach(function(category){
 						if(start.indexOf(category) == -1){
 							start = start.concat(category);
 						}

--- a/lib/wheat/data.js
+++ b/lib/wheat/data.js
@@ -274,6 +274,41 @@ var Data = module.exports = {
     );
   }),
 
+  categories: Git.safe(function articles(version, callback) {
+    Step(
+      function getListOfArticles() {
+        Git.readDir(version, "articles", this);
+      },
+      function readArticles(err, results) {
+        if (err) { callback(err); return; }
+        var group = this.group();
+        results.files.forEach(function onFile(filename) {
+          if (!(/\.markdown$/.test(filename))) {
+            return;
+          }
+          var name = filename.replace(/\.markdown$/, '');
+          Data.article(version, name, group());
+        });
+      },
+      function processCategories(err, articles) {
+        if (err) { callback(err); return; }
+        var categories = articles.reduce(function (start, element) {
+					var articleCategories = element.categories.split(',').map(function(element){ 
+						return element.trim();
+					});
+					articleCategories.forEach(function(category){
+						if(start.indexOf(category) == -1){
+							start = start.concat(category);
+						}
+					});
+					return start;
+        }, []);
+        return categories;
+      },
+      callback
+    )
+  }),
+
   fullArticles: Git.safe(function fullArticles(version, callback) {
     Step(
       function getListOfArticles() {

--- a/lib/wheat/data.js
+++ b/lib/wheat/data.js
@@ -2,7 +2,8 @@ var Git = require('git-fs'),
     Path = require('path'),
     Step = require('step'),
     sys = require('sys'),
-    Script = process.binding('evals').Script;
+    Script = process.binding('evals').Script,
+    QueryString = require('querystring');
 
 function preProcessMarkdown(markdown) {
   if (!(typeof markdown === 'string')) {
@@ -208,7 +209,7 @@ var Data = module.exports = {
 
         if(props.categories != undefined){
           props.categories = props.categories.split(',').map(function(element){ 
-            return element.trim();
+            return QueryString.escape(element.trim());
           });
         }
         return props;

--- a/lib/wheat/renderers.js
+++ b/lib/wheat/renderers.js
@@ -106,12 +106,14 @@ var Renderers = module.exports = {
         if (err) { callback(err); return; }
         Data.articles(version, this.parallel());
         Git.readFile(head, "description.markdown", this.parallel());
+				Data.categories(version, this.parallel());
       },
-      function applyTemplate(err, articles, description) {
+      function applyTemplate(err, articles, description, categories) {
         if (err) { callback(err); return; }
         Tools.render("index", {
           articles: articles,
-          description: description
+          description: description,
+					categories: categories
         }, this);
       },
       function callPostProcess(err, buffer) {
@@ -186,6 +188,40 @@ var Renderers = module.exports = {
         postProcess({
           "Cache-Control": "public, max-age=3600"
         }, buffer, version, name, this);
+      },
+      callback
+    );
+  }),
+
+  categoryIndex: Git.safe(function index(version, category, callback) {
+    Step(
+      function getHead() {
+        Git.getHead(this);
+      },
+      function loadData(err, head) {
+        if (err) { callback(err); return; }
+        Data.articles(version, this.parallel());
+        Git.readFile(head, "description.markdown", this.parallel());
+				Data.categories(version, this.parallel());
+      },
+      function applyTemplate(err, articles, description, categories) {
+        if (err) { callback(err); return; }
+				
+				var articlesForCategory = articles.reduce(function (start, element){
+					return element.categories.indexOf(category) >= 0 ? start.concat(element) : start;
+				}, []);
+								
+        Tools.render("index", {
+          articles: articlesForCategory,
+          description: description,
+					categories: categories
+        }, this);
+      },
+      function callPostProcess(err, buffer) {
+        if (err) { callback(err); return; }
+        postProcess({
+          "Cache-Control": "public, max-age=3600"
+        }, buffer, version, "index", this);
       },
       callback
     );


### PR DESCRIPTION
Hi Tim,

I've been looking into the sources of howtonode.org and there I found wheat. I loved the idea of a blog engine entirely based on gitfs and markdown and, so, I decided to try it out and build my own personal blog. 

As a result, I've added support of categories/tags into wheat. To work, it is only necessary to add the article's categories in the header of the markdown file, as comma-separated values. You can see an example here:
http://github.com/acmarques/randomthoughts/raw/master/articles/deploying_node_with_nginx_and_god.markdown
There is also a new route, '/category/#{value}', used to index articles in the selected category.

You can see it working here, in my personal blog written using wheat: http://blog.acmarques.com .

Lastly, I would like to thank you by the many contributions you are doing in node.js, I'm learning a lot reading your code and howtonode.org!

Hope my changes are useful. Any doubts or problems, please let me know.

Tks,

Antonio
