### PR TITLE
V0.3.0 compatibility

### DIFF
--- a/lib/wheat/data.js
+++ b/lib/wheat/data.js
@@ -1,7 +1,7 @@
 var Git = require('git-fs'),
     Path = require('path'),
     Step = require('step'),
-    sys = require('sys'),
+    util = require(process.binding('natives').util ? 'util' : 'sys'),
     Script = process.binding('evals').Script,
     QueryString = require('querystring');
 
@@ -78,7 +78,7 @@ function sandbox(snippet) {
       },
       dir: function fakeP(data) {
         arguments.forEach(function (data) {
-          snippet.output += sys.inspect(data) + "\n";
+          snippet.output += util.inspect(data) + "\n";
         });
       }
     }  };

--- a/lib/wheat/tools.js
+++ b/lib/wheat/tools.js
@@ -1,5 +1,4 @@
-var Sys = require('sys'),
-    Step = require('step'),
+var Step = require('step'),
     Haml = require('haml'),
     Markdown = require('./markdown'),
     MD5 = require('./md5'),
@@ -36,7 +35,7 @@ var aMonths = new Array("Jan", "Feb", "Mar", "Apr", "May", "Jun",
 var aDays = new Array( "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat");
 
 var Helpers = {
-  inspect: Sys.inspect,
+  inspect: require(process.binding('natives').util ? 'util' : 'sys').inspect,
   intro: function intro(markdown) {
     var html = Markdown.encode(markdown);
     return html.substr(0, html.indexOf("<h2"));

--- a/lib/wheat/tools.js
+++ b/lib/wheat/tools.js
@@ -117,7 +117,7 @@ var Helpers = {
 // Convert UTF8 strings to binary buffers for faster loading
 function stringToBuffer(string) {
   var buffer = new Buffer(Buffer.byteLength(string));
-  buffer.utf8Write(string);
+  buffer.write(string, 'utf8');
   return buffer;
 };
 


### PR DESCRIPTION
This is what was needed to support node's v0.3 API (specifically, the rename from `sys` to `util`). It remains backwards compatible with the v0.2 branch.
