### PR TITLE
Implement 'process.stdout' in the sandbox.

### DIFF
--- a/lib/wheat/data.js
+++ b/lib/wheat/data.js
@@ -59,33 +59,53 @@ function preProcessMarkdown(markdown) {
 function sandbox(snippet) {
   snippet.result = "";
   snippet.output = "";
-  var fakeRequire = function fakeRequire(path) {
+  function fakeRequire(path) {
     var lib = require(path);
     return lib;
-  };
+  }
+  // Create a 'pseudo-write-stream', to act as the virtual 'stdout' stream.
+  var stdout = new (require('stream').Stream)();
+  stdout.writable = true;
+  stdout.write = function(buf, enc) {
+    if (!this.writable) throw new Error("Stream is not writable");
+    if (!Buffer.isBuffer(buf)) {
+      buf = new Buffer(buf, enc);
+    }
+    this.emit('data', buf);
+  }
+  stdout.end = function(buf, enc) {
+    if (buf) { this.write(buf, enc); }
+    this.writable = false;
+  }
+  stdout.on('data', function(data) {
+    snippet.output += data.toString();
+  });
+  
   var env = {
     clear: function () { snippet.output = ""; },
     require: fakeRequire,
     process: {
       exit: function fakeExit() {},
-      argv: ['node', snippet.filename]
+      argv: [process.argv[0], snippet.filename],
+      stdout: stdout
     },
     console: {
-      log: function fakePuts() {
+      log: function fakeLog() {
         arguments.forEach(function (data) {
-          snippet.output += data + "\n";
+          stdout.write(data + "\n");
         });
       },
-      dir: function fakeP(data) {
+      dir: function fakeDir() {
         arguments.forEach(function (data) {
-          snippet.output += sys.inspect(data) + "\n";
+          stdout.write(sys.inspect(data) + "\n");
         });
       }
-    }  };
+    }
+  };
   env.process.__proto__ = process;
 
   var toRun = (snippet.beforeCode ? (snippet.beforeCode + "\nclear();\n") : "") + snippet.code;
-  console.log(toRun);
+  //console.log(toRun);
 
   try {
     snippet.lastExpression = Script.runInNewContext(toRun, env, snippet.filename);


### PR DESCRIPTION
Hey Tim. I just thought you might want to merge this patch that adds `process.stdout` to the script sandbox in Wheat. The example scripts I am trying to run on my article are attempting to access process.stdout, which didn't exist!

I think this is a nice clean implementation that creates a "virtual" write stream that simply appends to `snippet.output` whenever it gets written to.

Note that this patch requires node v0.3, for use of the new `Stream` class, so you may want to wait until that is landed before merging.
