### PR TITLE
Added support for git file versions in snippets 

### DIFF
--- a/lib/wheat/data.js
+++ b/lib/wheat/data.js
@@ -23,8 +23,9 @@ function preProcessMarkdown(markdown) {
 
   // Look for snippet placeholders
   var unique = props.uniqueSnippets = {};
-  props.snippets = (markdown.match(/\n<[^<>:\s]+\.[a-z]{2,4}(\*|[#].+)?>\n/g) || []).map(
+  props.snippets = (markdown.match(/\n<[^<>:\s]+\.[a-z]{2,4}(\*|[#|\:].+)?>\n/g) || []).map(
     function (original) {
+      // nuke the leading and trailing /n< and >/n
       var path = original.substr(2, original.length - 4);
 
       var filename = path;
@@ -32,26 +33,32 @@ function preProcessMarkdown(markdown) {
       if (execute) {
         filename = filename.substr(0, filename.length - 1);
       }
-      base = path.substr(path.indexOf('/') + 1).replace(/[#*].*$/, '');
+      base = path.substr(path.indexOf('/') + 1).replace(/[(#|\:)*].*$/, '');
       var match = filename.match(/#(.+)$/);
       var name;
       if (match) {
         name = match[1];
         filename = path.substr(0, match.index);
       }
+      var version = 'fs';
+      match = filename.match(/\:(.+)$/);
+      if (match) {
+          version = match[1];
+          filename = path.substr(0, match.index);
+      }
       return unique[base] = {
         original: original,
         filename: filename,
         execute: execute,
         base: base,
-        name: name
+        name: name,
+        version: version
       };
     }
   );
   if (props.snippets.length === 0) {
     props.uniqueSnippets = false;
   }
-
 
   return props;
 }
@@ -123,7 +130,7 @@ function activateSnippets(version, snippets, canExecute, callback) {
       }
       var group = this.group();
       snippets.forEach(function (snippet) {
-        Git.readFile(version, "articles/" + snippet.filename, group());
+        Git.readFile(snippet.version, "articles/" + snippet.filename, group());
       });
     },
     function (err, files) {


### PR DESCRIPTION
 CONTEXT
Wheat currently supports snippets that are demarcated by a newline < > newline.

Inside of the snippet's brackets, you can specify the relative path from one of
Wheat's markdown articles to a code snippet. In addition to that, wheat can
handle those snippets in different ways.

A snippet ending in a _, for example foo/bar.baz_. Will be executed and the
result shown beneath the snippet in final rendering.

A snippet ending in a #label will look inside the snippet file for a comment
and display from that #forward.

For instance, foo/bar.baz#doAwesomeStuff will look for:

 //doAwesomeStuff
 doSomethingAwesome();

 //doSomethingLessAwesome
 doLesserThings();

and diaplay just the doSomethingAwesome.

CHANGE MOTIVIATION
This change proposes the addition of an additional syntax, :SHA which will
get a specific version of a file in Wheat's git repository.

One would want this when building out a demo application step by step. If you
make a project directory under articles and commit to it piece by piece, it is
very natural as a developer.

On the other hand, right now when using Wheat, a developer often makes multiple
copies of the same file for instance app.js, app2.js, app-final.js to use as
snippets during different stages of the article. If you're not careful, this
can get confusing (speaking from experience here using Wheat) especially if
you go to update an article you wrote a while back.

CHANGE USAGE
With this change, you can use the below as the content of a snippet:

foo/bar.baz:aaaaabbbbbcccccdddddeeeeefffff1111100040
and
foo/bar.baz:ffffffffffffffffffffffffffffffffff00040

and get different versions of the same file from git.

When using this feature, you must specify the full 40 character git SHA and it
does not work with # (although it does work with *) -- the theory being do the
smallest change possible.
