### PR TITLE
read files in utf8 (issue #28)

### DIFF
--- a/lib/wheat/data.js
+++ b/lib/wheat/data.js
@@ -129,6 +129,9 @@ function activateSnippets(version, snippets, canExecute, callback) {
     function (err, files) {
       if (err) { callback(err); return; }
       files.forEach(function (code, i) {
+        if (!(typeof code === 'string')) {
+          code = code.toString();
+        }
         var snippet = snippets[i];
 
         if (snippet.name) {
@@ -300,6 +303,24 @@ var Data = module.exports = {
       callback
     );
   }),
+  
+    // Loads a markdownfile.
+    markdownFile: Git.safe(function markdownFile(version, filename, callback) {
+     Step(
+       function getMarkdown() {
+         if (!filename) {
+           callback(new Error("filename is required"));
+           return;
+         }
+         Git.readFile(version, filename, this);
+       },
+       function process(err, markdown) {
+         if (err) { callback(err); return; }
+         return preProcessMarkdown(markdown);
+       },
+       callback
+     );
+   }),
 
   categories: Git.safe(function articles(version, callback) {
     Step(

--- a/lib/wheat/renderers.js
+++ b/lib/wheat/renderers.js
@@ -174,7 +174,7 @@ var Renderers = module.exports = {
         if (err) { callback(err); return; }
         article = props;
         insertSnippets(article.markdown, article.snippets, this.parallel());
-        Git.readFile(head, "description.markdown", this.parallel());
+        Data.markdownFile(head, "description.markdown", this.parallel());
       },
       function applyTemplate(err, markdown, description) {
         if (err) { callback(err); return; }
@@ -241,14 +241,17 @@ var Renderers = module.exports = {
         }
         return data;
       },
-      function processFile(err, string) {
+      function processFile(err, data) {
         if (err) { callback(err); return; }
         var headers = {
           "Content-Type": getMime(path),
           "Cache-Control": "public, max-age=32000000"
         };
-        var buffer = new Buffer(string.length);
-        buffer.write(string, 'binary');
+        var buffer = data;
+        if (typeof markdown === 'string') {
+          buffer = new Buffer(data.length);
+          buffer.write(data, 'binary');
+        }
         postProcess(headers, buffer, version, path, this);
       },
       callback

--- a/lib/wheat/tools.js
+++ b/lib/wheat/tools.js
@@ -128,6 +128,9 @@ var loadTemplate = Git.safe(function loadTemplate(version, name, callback) {
     },
     function compileTemplate(err, haml) {
       if (err) { callback(err); return; }
+      if (!(typeof haml === 'string')) {
+        haml = haml.toString();
+      }
       return Haml(haml, (/\.xml$/).test(name));
     },
     callback


### PR DESCRIPTION
to get this to work on utf8 files git-fs.js line 243 must be changed:

```
 // Or load from the fs directly if requested.
```
-    fs.readFile(Path.join(workTree, path), 'binary', function (err, data) {
-   fs.readFile(Path.join(workTree, path), function (err, data) {
   if (err) {
     if (err.errno === process.ENOENT) {
       err.message += " " + JSON.stringify(path);

without this change in git-fs the application should still run but still no proper handling of ä,ö,ü,...
