### PR TITLE
Assume UTF-8 encoding for .markdown and .haml - using new Git.readFile functionality

### DIFF
--- a/lib/wheat/data.js
+++ b/lib/wheat/data.js
@@ -6,9 +6,6 @@ var Git = require('git-fs'),
     QueryString = require('querystring');
 
 function preProcessMarkdown(markdown) {
-  if (!(typeof markdown === 'string')) {
-    markdown = markdown.toString();
-  }
   var props = { };
 
   // Parse out headers
@@ -80,7 +77,7 @@ function sandbox(snippet) {
   stdout.on('data', function(data) {
     snippet.output += data.toString();
   });
-  
+
   var env = {
     clear: function () { snippet.output = ""; },
     require: fakeRequire,
@@ -123,7 +120,7 @@ function activateSnippets(version, snippets, canExecute, callback) {
       }
       var group = this.group();
       snippets.forEach(function (snippet) {
-        Git.readFile(version, "articles/" + snippet.filename, group());
+        Git.readFile(version, "articles/" + snippet.filename, "utf8", group());
       });
     },
     function (err, files) {
@@ -181,7 +178,7 @@ var Data = module.exports = {
           filename = path.substr(0, match.index);
         }
         url = "/" + (version === "fs" ? "" : version + "/") + filename;
-        Git.readFile(version, "articles/" + filename, this);
+        Git.readFile(version, "articles/" + filename, "utf8", this);
       },
       function (err, code) {
         if (err) { error(err); return; }
@@ -208,7 +205,7 @@ var Data = module.exports = {
     var props;
     Step(
       function getArticleMarkdown() {
-        Git.readFile(version, Path.join("articles", name + ".markdown"), this);
+        Git.readFile(version, Path.join("articles", name + ".markdown"), "utf8", this);
       },
       function (err, markdown) {
         if (err) { callback(err); return; }
@@ -228,7 +225,7 @@ var Data = module.exports = {
         props.author = author;
 
         if(props.categories != undefined){
-          props.categories = props.categories.split(',').map(function(element){ 
+          props.categories = props.categories.split(',').map(function(element){
             return QueryString.escape(element.trim());
           });
         }
@@ -286,7 +283,7 @@ var Data = module.exports = {
           callback(new Error("name is required"));
           return;
         }
-        Git.readFile(version, Path.join("authors", name + ".markdown"), this);
+        Git.readFile(version, Path.join("authors", name + ".markdown"), "utf8", this);
       },
       function process(err, markdown) {
         if (err) { callback(err); return; }

--- a/lib/wheat/renderers.js
+++ b/lib/wheat/renderers.js
@@ -108,15 +108,15 @@ var Renderers = module.exports = {
       function loadData(err, head) {
         if (err) { callback(err); return; }
         Data.articles(version, this.parallel());
-        Git.readFile(head, "description.markdown", this.parallel());
-				Data.categories(version, this.parallel());
+        Git.readFile(head, "description.markdown", "utf8", this.parallel());
+        Data.categories(version, this.parallel());
       },
       function applyTemplate(err, articles, description, categories) {
         if (err) { callback(err); return; }
         Tools.render("index", {
           articles: articles,
           description: description,
-					categories: categories
+          categories: categories
         }, this);
       },
       function callPostProcess(err, buffer) {
@@ -174,7 +174,7 @@ var Renderers = module.exports = {
         if (err) { callback(err); return; }
         article = props;
         insertSnippets(article.markdown, article.snippets, this.parallel());
-        Git.readFile(head, "description.markdown", this.parallel());
+        Git.readFile(head, "description.markdown", "utf8", this.parallel());
       },
       function applyTemplate(err, markdown, description) {
         if (err) { callback(err); return; }
@@ -204,20 +204,20 @@ var Renderers = module.exports = {
       function loadData(err, head) {
         if (err) { callback(err); return; }
         Data.articles(version, this.parallel());
-        Git.readFile(head, "description.markdown", this.parallel());
-				Data.categories(version, this.parallel());
+        Git.readFile(head, "description.markdown", "utf8", this.parallel());
+        Data.categories(version, this.parallel());
       },
       function applyTemplate(err, articles, description, categories) {
         if (err) { callback(err); return; }
-				
+
         var articlesForCategory = articles.reduce(function (start, element){
           return element.categories && element.categories.indexOf(category) >= 0 ? start.concat(element) : start;
         }, []);
-								
+
         Tools.render("index", {
           articles: articlesForCategory,
           description: description,
-					categories: categories
+          categories: categories
         }, this);
       },
       function callPostProcess(err, buffer) {
@@ -241,15 +241,13 @@ var Renderers = module.exports = {
         }
         return data;
       },
-      function processFile(err, string) {
+      function processFile(err, data) {
         if (err) { callback(err); return; }
         var headers = {
           "Content-Type": getMime(path),
           "Cache-Control": "public, max-age=32000000"
         };
-        var buffer = new Buffer(string.length);
-        buffer.write(string, 'binary');
-        postProcess(headers, buffer, version, path, this);
+        postProcess(headers, data, version, path, this);
       },
       callback
     );

--- a/lib/wheat/tools.js
+++ b/lib/wheat/tools.js
@@ -124,7 +124,7 @@ function stringToBuffer(string) {
 var loadTemplate = Git.safe(function loadTemplate(version, name, callback) {
   Step(
     function loadHaml() {
-      Git.readFile(version, "skin/" + name + ".haml", this);
+      Git.readFile(version, "skin/" + name + ".haml", "utf8", this);
     },
     function compileTemplate(err, haml) {
       if (err) { callback(err); return; }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "engines": ["node >= 0.4.0"],
   "main": "lib/wheat.js",
   "dependencies": {
-    "git-fs": ">=0.0.5",
+    "git-fs": ">=0.0.7",
     "simple-mime": ">=0.0.1",
     "haml": ">=0.2.5",
     "step": ">=0.0.3",


### PR DESCRIPTION
Only pull after new version of git-fs is published to npm.
This should fix encoding problems #18, #28 etc.
Tested with howtonode.org - seems OK.

Reads .markdown, .haml and snippets as "utf8"
Everything else is read as raw buffers - no conversion needed.
