### PR TITLE
0.6.x compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/lib/wheat.js
+++ b/lib/wheat.js
@@ -20,12 +20,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-require.paths.unshift(__dirname + "/wheat");
-
 require('proto');
 var Url = require('url'),
     Git = require('git-fs'),
-    Renderers = require('renderers');
+    Renderers = require('./wheat/renderers');
 
 var routes = [];
 


### PR DESCRIPTION
Fixes to make `wheat` work on node v0.6.0.

Closes #36.
