### PR TITLE
changed path.join on Git.readFile calls since Windows will use backslash...

### DIFF
--- a/lib/wheat/data.js
+++ b/lib/wheat/data.js
@@ -209,7 +209,7 @@ var Data = module.exports = {
     var props;
     Step(
       function getArticleMarkdown() {
-        Git.readFile(version, Path.join("articles", name + ".markdown"), this);
+        Git.readFile(version, "articles/" + name + ".markdown", this);
       },
       function (err, markdown) {
         if (err) { callback(err); return; }
@@ -287,7 +287,7 @@ var Data = module.exports = {
           callback(new Error("name is required"));
           return;
         }
-        Git.readFile(version, Path.join("authors", name + ".markdown"), this);
+        Git.readFile(version, "authors/" + name + ".markdown", this);
       },
       function process(err, markdown) {
         if (err) { callback(err); return; }


### PR DESCRIPTION
... and that will break git show commands (that expects a forward slash %sha%/articles/control-flow.markdown)
