### PR TITLE
fix snippet sandboxed execution and snippet regex

### DIFF
--- a/lib/wheat/data.js
+++ b/lib/wheat/data.js
@@ -2,7 +2,7 @@ var Git = require('git-fs'),
     Path = require('path'),
     Step = require('step'),
     util = require(process.binding('natives').util ? 'util' : 'sys'),
-    Script = process.binding('evals').Script,
+    Script = require('vm'),
     QueryString = require('querystring');
 
 function preProcessMarkdown(markdown) {
@@ -23,10 +23,10 @@ function preProcessMarkdown(markdown) {
 
   // Look for snippet placeholders
   var unique = props.uniqueSnippets = {};
-  props.snippets = (markdown.match(/\n<[^<>:\s]+\.[a-z]{2,4}(\*|[#].+)?>\n/g) || []).map(
+  props.snippets = (markdown.match(/(\r\n|\n)<[^<>:\s]+\.[a-z]{2,4}(\*|[#].+)?>(\r\n|\n)/g) || []).map(
     function (original) {
-      var path = original.substr(2, original.length - 4);
-
+      var path = original.slice(original.indexOf("<")+1, original.indexOf(">"));
+      
       var filename = path;
       execute = path[path.length - 1] === "*";
       if (execute) {


### PR DESCRIPTION
snippet regex work on windows \r\n (for win) \n (for *nix)
Both things were tested in both Mac and Windows
