### PR TITLE
attempt to remove execPipe function

### DIFF
--- a/lib/wheat/renderers.js
+++ b/lib/wheat/renderers.js
@@ -8,42 +8,6 @@ var Git = require('git-fs'),
     getMime = require('simple-mime')('application/octet-string'),
     Step = require('step');
 
-// Execute a child process, feed it a buffer and get a new buffer filtered.
-function execPipe(command, args, data, callback) {
-  var child = ChildProcess.spawn(command, args);
-  var stdout = [], stderr = [], size = 0;
-  child.stdout.on('data', function onStdout(buffer) {
-    size += buffer.length;
-    stdout[stdout.length] = buffer;
-  });
-  child.stderr.on('data', function onStderr(buffer) {
-    stderr[stderr.length] = buffer;
-  });
-  child.on('error', function onExit(err) {
-    callback(err);
-  });
-  child.on('exit', function onExit(code) {
-    if (code > 0) {
-      callback(new Error(stderr.join("")));
-    } else {
-      var buffer = new Buffer(size);
-      var start = 0;
-      for (var i = 0, l = stdout.length; i < l; i++) {
-        var chunk = stdout[i];
-        chunk.copy(buffer, start);
-        start += chunk.length;
-      }
-      callback(null, buffer);
-    }
-  });
-  if (typeof data === 'string') {
-    child.stdin.write(data, "binary");
-  } else {
-    child.stdin.write(data);
-  }
-  child.stdin.end();
-}
-
 // This writes proper headers for caching and conditional gets
 // Also gzips content if it's text based and stable.
 function postProcess(headers, buffer, version, path, callback) {
@@ -268,7 +232,7 @@ var Renderers = module.exports = {
       },
       function processFile(err, data) {
         if (err) { callback(err); return; }
-        execPipe("dot", ["-Tpng"], data, this);
+        ChildProcess.exec("dot -Tpng", this).stdin.end(data, 'binary');
       },
       function finish(err, buffer) {
         if (err) { callback(err); return; }

--- a/lib/wheat/renderers.js
+++ b/lib/wheat/renderers.js
@@ -232,10 +232,11 @@ var Renderers = module.exports = {
       },
       function processFile(err, data) {
         if (err) { callback(err); return; }
-        ChildProcess.exec("dot -Tpng", this).stdin.end(data, 'binary');
+        ChildProcess.exec('dot -Tpng', { encoding: 'binary' }, this).stdin.end(data)
       },
       function finish(err, buffer) {
         if (err) { callback(err); return; }
+        buffer = new Buffer(buffer, 'binary')
         postProcess({
           "Content-Type": "image/png",
           "Cache-Control": "public, max-age=32000000"


### PR DESCRIPTION
The exec Pipe function looks to do about the same as what child_process.exec does.
I thought that it should be removed and use child_process.exec instead.

Currently this is not ready to merge.  At the moment the graphs images don't render correctly.  They are about 5% smaller.  Any ideas why this isn't working?
