### PR TITLE
Is Git.getHead() necessary in wheat.js?

### DIFF
--- a/lib/wheat.js
+++ b/lib/wheat.js
@@ -68,16 +68,9 @@ module.exports = function setup(repo) {
       var match = url.pathname.match(route.regex);
       if (match) {
         match = Array.prototype.slice.call(match, 1);
-        if (match[0] === '') {
-          // Resolve head to a sha if unspecified
-          Git.getHead(function (err, sha) {
-            if (err) { throw err; }
-            match[0] = sha;
-            handleRoute(req, res, next, route.renderer, match);
-          });
-        } else {
-          handleRoute(req, res, next, route.renderer, match);
-        }
+        // If it didn't match a SHA, set to "fs"
+        match[0] = match[0] || "fs";
+        handleRoute(req, res, next, route.renderer, match);
         return;
       }
     }


### PR DESCRIPTION
WARNING: If this has something to do with cacheing / the "safe" function in Git, I have no idea, because I honestly don't understand that stuff at all.

Makes an  if/else branch unnecessary.

I've tested this on a clone of howtonode.org and it seems to work.

I believe Git.getHead() should always return fs, because my understanding is that the HEAD in Git only moves on checkouts and commits?

I stuck a console.log(sha) in a clone of howtonode.org and clicked all over the site and never got anything but fs. Besides that, the only place the head seems to be used anywhere in wheat is on reading the "description.markdown" file. I figured the lines might have something to do with reading the same version of other files (eg. authors.markdown) that were in place at the time of that particular commit, but behavior seems to be the same with the patch in place.
