### PR TITLE
Correct bitbucket host in tools

### DIFF
--- a/lib/wheat/tools.js
+++ b/lib/wheat/tools.js
@@ -19,7 +19,7 @@ var Helpers = {
     return '<a href="http://github.com/' + name + '">' + name + '</a>';
   },
   bitbucket: function bitbucket(name) {
-    return '<a href="http://bitbucket.com/' + name + '">' + name + '</a>';
+    return '<a href="http://bitbucket.org/' + name + '">' + name + '</a>';
   },
   twitter: function twitter(name) {
     return '<a href="http://twitter.com/' + name + '">' + name + '</a>';


### PR DESCRIPTION
bitbucket host is .org not .com.  Corrected.
