### PR TITLE
Link with protocol breaks https

### DIFF
--- a/lib/wheat/tools.js
+++ b/lib/wheat/tools.js
@@ -28,7 +28,7 @@ var Helpers = {
     size = size || 200;
     var hash = Crypto.createHash('md5')
     hash.update((email+"").trim().toLowerCase())
-    return "http://www.gravatar.com/avatar/" +
+    return "//www.gravatar.com/avatar/" +
       hash.digest('hex') +
       "?r=pg&s=" + size + ".jpg&d=identicon";
   },


### PR DESCRIPTION
You can make this link without including the protocol, safely and so that any site served via HTTPS does not cause warnings about unsecured content on the page.  Any visitors with document.location that starts with https: will go to https://gravatar... etc and any visitors with otherwise or http: browser's document.location will not notice any difference.  This change, and removal of the manning affiliate hrefs, make the lock turn green on my website.
